### PR TITLE
Add "bluetooth" to control bluetooth via `bluetoothctl`

### DIFF
--- a/bluetooth
+++ b/bluetooth
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+program="rw-bluetooth"
+
+# TODO: Add a command to show connected devices (non selectable).
+
+cmd_enable_bt="Enable bluetooth"
+cmd_disable_bt="Disable bluetooth"
+cmd_scan_dev="Scan devices"
+cmd_disconnect_dev="Disconnect from device(s)"
+cmd_exit="exit"
+
+diag_message=""
+
+connect() {
+    rofi -e "Connecting to $2..." &
+    placeholder_pid=$!
+
+    if ! bluetoothctl trust "$1" > /dev/null; then
+        diag_message="Failed to trust to device $2. Try again..."
+
+        kill "$placeholder_pid"
+        return 0
+    elif ! bluetoothctl connect "$1" > /dev/null; then
+        diag_message="Failed to connect to device $2. Try again..."
+
+        kill "$placeholder_pid"
+        return 0
+    fi
+
+    diag_message="Connected to the device: $2."
+
+    kill "$placeholder_pid"
+    return 0
+}
+
+scan() {
+    rofi -e "Scanning for devices..." &
+    placeholder_pid=$!
+
+    bluetoothctl --timeout 5 scan on > /dev/null
+
+    devices=()
+    addresses=()
+    while read -r line;
+    do
+        IFS=' ' read -r _ address dev_name <<< "$line"
+        if [ "${address//:/-}" != "$dev_name" ]; then
+            devices+=("$dev_name")
+            addresses+=("$address")
+        fi
+    done < <(bluetoothctl devices)
+    kill "$placeholder_pid"
+
+    dev_list=$(IFS=$'\n' ;echo "${devices[*]}")
+    selected_dev=$(echo -e "$dev_list" | rofi -dmenu -i -p "device (type scan to rescan): ")
+
+    if [[ -z "$selected_dev" ]]; then
+        diag_message="No device is selected to connect. Try again..."
+        return 0
+    fi
+
+    if [[ "$selected_dev" = "scan" ]]; then
+        scan
+        return 0
+    fi
+
+    if ! grep -q "$selected_dev" <<< "$dev_list"; then
+        diag_message="Selected device is not found: $selected_dev"
+        return 0
+    fi
+
+    selected_addr=""
+    for i in "${!devices[@]}"; do
+        if [[ "${devices[$i]}" = "$selected_dev" ]];then
+            selected_addr="${addresses[$i]}"
+            break
+        fi
+    done
+
+    connect "$selected_addr" "$selected_dev"
+}
+
+disconnect() {
+    devices=()
+    addresses=()
+    while read -r line; do
+        IFS=' ' read -r _ address dev_name <<< "$line"
+
+        devices+=("$dev_name")
+        addresses+=("$address")
+    done <<< "$1"
+
+    dev_list=$(IFS=$'\n' ;echo "${devices[*]}")
+    selected_dev=$(echo -e "$dev_list" | rofi -dmenu -i -p "device to disconnect: ")
+
+    if [[ -z "$selected_dev" ]]; then
+        diag_message="No device is selected to disconnect. Try again..."
+        return 0
+    fi
+
+    if ! grep -q "$selected_dev" <<< "$dev_list"; then
+        diag_message="Selected device is not found: $selected_dev. Try again..."
+        return 0
+    fi
+
+    selected_addr=""
+    for i in "${!devices[@]}"; do
+        if [[ "${devices[$i]}" = "$selected_dev" ]];then
+            selected_addr="${addresses[$i]}"
+            break
+        fi
+    done
+
+    if ! bluetoothctl disconnect "$selected_addr" > /dev/null; then
+        diag_message="Unable to disconnect from $selected_dev"
+    else
+        diag_message="Disconnected from $selected_dev."
+    fi
+
+    return 0
+}
+
+main() {
+    commands=()
+
+    if bluetoothctl -- show | grep -q 'PowerState: on'; then
+        commands+=("$cmd_disable_bt")
+    else
+        commands+=("$cmd_enable_bt")
+    fi
+
+    commands+=("$cmd_scan_dev")
+
+    connected_devices=$(bluetoothctl -- devices Connected)
+    if [ -n "$connected_devices" ]; then
+        commands+=("$cmd_disconnect_dev")
+    fi
+
+    cmd_menu_items=$(IFS=$'\n' ;echo "${commands[*]}")
+
+    if [[ -z "$diag_message" ]]; then
+        cmd=$(echo -e "$cmd_menu_items" | rofi -dmenu -i -p "command (type $cmd_exit to close):")
+    else
+        cmd=$(echo -e "$cmd_menu_items" | rofi -dmenu -mesg "$diag_message" -i -p "command (type $cmd_exit to close):")
+        diag_message=""
+    fi
+
+    case "$cmd" in
+        "$cmd_enable_bt")
+            bluetoothctl power on > /dev/null
+            diag_message="Bluetooth is enabled."
+            ;;
+        "$cmd_disable_bt")
+            bluetoothctl power off > /dev/null
+            diag_message="Bluetooth is disabled."
+            ;;
+        "$cmd_scan_dev")
+            scan
+            ;;
+        "$cmd_disconnect_dev")
+            disconnect "$connected_devices"
+            ;;
+        "$cmd_exit")
+            exit 0
+            ;;
+        *)
+            echo "$program: invalid option: $cmd"
+            ;;
+    esac
+
+    main
+}
+
+main

--- a/power
+++ b/power
@@ -5,9 +5,9 @@ set -euo pipefail
 program="rw-power"
 
 menu_items="Log out\nRestart\nKill"
-selection=$(echo -e "$menu_items" | rofi -dmenu -i -p "selection:")
+cmd=$(echo -e "$menu_items" | rofi -dmenu -i -p "selection:")
 
-case "$selection" in
+case "$cmd" in
     "Log out")
         loginctl terminate-user "$USER"
         ;;
@@ -18,6 +18,6 @@ case "$selection" in
         systemctl poweroff
         ;;
     *)
-        echo "$program: invalid option: $selection"
-        exit 0
+        echo "$program: invalid option: $cmd"
+        ;;
 esac

--- a/wifi
+++ b/wifi
@@ -136,7 +136,7 @@ main() {
     cmd_menu_items=$(IFS=$'\n' ;echo "${commands[*]}")
 
     cmd=""
-    if [ -z "$diag_message" ]; then
+    if [[ -z "$diag_message" ]]; then
         cmd=$(echo -e "$cmd_menu_items" | rofi -dmenu -i -p "command (type $cmd_exit to close):")
     else
         cmd=$(echo -e "$cmd_menu_items" | rofi -dmenu -mesg "$diag_message" -i -p "command (type $cmd_exit to close):")

--- a/wifi
+++ b/wifi
@@ -4,6 +4,8 @@ set -euo pipefail
 
 program="rw-wifi"
 
+# TODO: Add a new command to remove a known network.
+
 cmd_turn_off_wifi="Turn off WiFi"
 cmd_turn_on_wifi="Turn on WiFi"
 cmd_connect="Connect to a network"
@@ -13,6 +15,8 @@ cmd_exit="exit"
 signal_threshold_low=40
 signal_threshold_mid=60
 signal_threshold_high=80
+
+diag_message=""
 
 connect() {
     rofi -e "Connecting..." &
@@ -24,10 +28,12 @@ connect() {
         rofi -e "Connecting to a known network..." &
         known_conn_pid=$!
 
-        if nmcli connection up id "$1"; then
-            kill "$known_conn_pid"
-            return 0
+        if ! nmcli connection up id "$1"; then
+            diag_message="Connection to the known network $1 has failed. Remove the known network and try again..."
         fi
+
+        kill "$known_conn_pid"
+        return 0
     fi
 
     kill "$conn_pid"
@@ -38,7 +44,7 @@ connect() {
     new_conn_pid=$!
 
     if ! nmcli device wifi connect "$1" password "$password"; then
-        echo "$program: could not connect to the network $1"
+        diag_message="Incorrect password for the network $1. Try again..."
     fi
 
     kill "$new_conn_pid"
@@ -92,8 +98,8 @@ scan() {
     network_name="${ssid:11}"
 
     if ! grep -q " $network_name " <(nmcli dev wifi list); then
-        echo "$program: network not found: $network_name" >&2
-        exit 1
+        diag_message="Network not found: $network_name"
+        return 0
     fi
 
     connect "$network_name"
@@ -104,10 +110,12 @@ disconnect() {
     rofi -e "Disconnecting from the network ${network_name}..." &
     placeholder_pid=$!
 
-    if nmcli connection down id "$network_name"; then
-        kill $placeholder_pid
-        return 0
+    if ! nmcli connection down id "$network_name"; then
+        diag_message="Failed to disconnect from the network $network_name. Try again..."
     fi
+
+    kill $placeholder_pid
+    return 0
 }
 
 main() {
@@ -126,9 +134,16 @@ main() {
     fi
 
     cmd_menu_items=$(IFS=$'\n' ;echo "${commands[*]}")
-    cmd_selection=$(echo -e "$cmd_menu_items" | rofi -dmenu -i -p "command (type $cmd_exit to close):")
 
-    case "$cmd_selection" in
+    cmd=""
+    if [ -z "$diag_message" ]; then
+        cmd=$(echo -e "$cmd_menu_items" | rofi -dmenu -i -p "command (type $cmd_exit to close):")
+    else
+        cmd=$(echo -e "$cmd_menu_items" | rofi -dmenu -mesg "$diag_message" -i -p "command (type $cmd_exit to close):")
+        diag_message=""
+    fi
+
+    case "$cmd" in
         "$cmd_turn_on_wifi")
             nmcli radio wifi on
             ;;
@@ -145,6 +160,7 @@ main() {
             exit 0
             ;;
         *)
+            diag_message="Invalid command provided: $cmd"
             ;;
     esac
 


### PR DESCRIPTION
Pairing a device via PIN code is not supported for now, since I do not need that functionality.

**Other Changes**

Diagnostic messages are added to all utilities. In case of an error, the user is redirected back to the main menu and a diagnostic message regarding their latest operation is shown under the command input.

The visuals will be added in a separate commit, along with README changes.