### PR TITLE
Introduce AURORA_LIB_PATH environment variable

### DIFF
--- a/arch/README.md
+++ b/arch/README.md
@@ -28,9 +28,30 @@ aurora install [package]...
 
 Here is how the installation works:
 
-- The AUR branch of a given package is cloned under `$HOME/lib/aur/<package>`.
+- The AUR branch of a given package is cloned under `$AURORA_LIB_PATH/<package>`.
 - `makepkg` is used to build the package first to understand whether key acquisition is needed.
 - (Optional) If the build process outputs a signature file, `aurora` tries to acquire it automatically.
 - `aurora` installs the package via `makepkg`, which eventually calls `pacman`.
 
 Basically, the steps are more or less the same that are listed on [Arch Wiki](https://wiki.archlinux.org/title/Arch_User_Repository#Installing_and_upgrading_packages).
+
+#### Environment variables
+
+Here are the environment variables that `aurora` uses for `aurora install`:
+
+`AURORA_LIB_PATH`
+
+This variable is used to define the clone path for the packages.
+
+By default, it is set to `$HOME/.local/lib`.
+
+Users can either define this in their shell configuration files (e.g. `.bashrc`, `.zshrc`) or provide the variable before running the command, like shown below:
+
+```bash
+# 1 - export can be done either in the current shell instance, or in the configuration files.
+$ export AURORA_LIB_PATH="/path/for/your/packages"
+$ aurora install package1 package2
+
+# 2 - provide the variable before the command.
+$ AURORA_LIB_PATH="/path/for/your/packages" aurora install package1 package2
+```

--- a/arch/aurora
+++ b/arch/aurora
@@ -7,6 +7,8 @@ program="aurora"
 install_cmd="install"
 aur_repo="git@github.com:archlinux/aur.git"
 
+pkg_lib_path="${AURORA_LIB_PATH:-$HOME/.local/lib}"
+
 # TODO: Implement package update and removal.
 
 acquire_key() {
@@ -19,16 +21,21 @@ acquire_key() {
     done
 
     if [[ "$imported" -eq 0 ]]; then
-        echo "$program: failed to acquire the PGP key for the package. Aborting the installation." >&2
+        echo "$program: failed to acquire the PGP key for the package, aborting the installation." >&2
         exit 1
     fi
 }
 
 install() {
+    if [[ ! -d "$pkg_lib_path" ]]; then
+        echo "$program: the path $pkg_lib_path does not exist, the directory will be created before the installation."
+        mkdir -p "$pkg_lib_path"
+    fi
+
     for pkg in "$@"; do
-        pkg_path="$HOME/lib/aur/$pkg"
+        pkg_path="$pkg_lib_path/$pkg"
         if [[ -d "$pkg_path" ]]; then
-            echo "$program: the path $pkg_path already exists, removing the previous directory first."
+            echo "$program: the path $pkg_path already exists, the previous directory will be removed."
             rm -rf "$pkg_path"
         fi
 


### PR DESCRIPTION
This variable is used to define the clone path for the packages that are specified for `aurora install`.

The default path is set to `$HOME/.local/lib` for a given package.