### PR TITLE
Add `fzjt` to open new tabs via `fzf`

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Here are the steps to install any script in this repository:
 If you wish to install, please read the docs first to see which dependencies you need:
 
 - [tmux scripts](./tmux/README.md)
+- [Zellij scripts](./zellij/README.md)
 - [Desktop environment scripts](./de/README.md)
 - [Arch Linux scripts](./arch/README.md)
 

--- a/zellij/README.md
+++ b/zellij/README.md
@@ -1,0 +1,53 @@
+# `zellij` Scripts
+
+The scripts in this group are mainly geared towards automating `zellij` management in a particular way.
+
+All scripts in this directory depend on having `zellij` installed on the host.
+
+## `fzjt`
+
+**Dependencies**: `fd, fzf`
+
+`fzjt` allows users to fuzzy-find and open the directories that are related with their Zellij sessions in separate Zellij tabs.
+
+This functionality also helps users organize their directories by their contents.
+
+It's easier to explain with pseudocode.
+Here is an example scenario:
+
+```bash
+# "work" and "personal" directories are defined to store work and personal related subdirectories (e.g. Git repositories).
+work_projects_path="$HOME/work"
+personal_projects_path="$HOME/personal"
+
+# The subdirectories.
+mkdir -p "$work_projects_path"/project{1..4}
+mkdir -p "$personal_projects_path"/project{1..4}
+
+# The corresponding tmux sessions.
+zellij -s work
+zellij -s personal
+
+# User attaches to the session "work" to deal with work projects.
+zellij a work
+
+# Using fzfw in the work session allows the user to search any directory that belongs "to $HOME/work".
+# Notice how the project directories created under "$HOME/personal" are not shown in the list.
+fzjt
+# "$HOME/work/project1"
+# "$HOME/work/project2"
+# "$HOME/work/project3"
+# "$HOME/work/project4"
+
+# Selecting project4 from the list provided by fzfw above.
+selected_dir="$HOME/work/project4"
+
+# fzjt opens project4 in a new window, titled "project4".
+zellij ac query-tab-names
+# 0: bash
+# 1: project4
+```
+
+If the directory structure is designed similar to the given example above, then `fzjt` makes it really a great experience to create Zellij tabs and switch between projects.
+
+The _automation_ aspect of the script can be felt better when the user is located in a deeply nested directory and wants to open up a new Zellij tab in a completely different place.

--- a/zellij/fzjt
+++ b/zellij/fzjt
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+program="fzjt"
+
+zellij_session=${ZELLIJ_SESSION_NAME:-}
+if [[ -z "$zellij_session" ]]; then
+  echo "$program: unable to find the active zellij session." >&2
+  exit 1
+fi
+
+path_to_search="$HOME/$zellij_session"
+selected_path=$(fd . "$path_to_search" --hidden -d 1 --type d | fzf)
+tab_name=$(echo "$selected_path" | awk -F "/" '{ if ($NF==""){print $(NF-1)}; if($NF!=""){print $NF} }')
+
+zellij ac new-tab -n "$tab_name" -c "$selected_path" -l "default"


### PR DESCRIPTION
Since I've changed my terminal multiplexer from `tmux` to `zellij`, I have been missing out the fzf -> window functionality on Zellij.

Therefore, the same functionality is implemented as a new program called `fzjt` (Fzf-ZelliJ-Tab).

The implementation is nearly the exact same with its `tmux` counterpart, therefore the README is kept as the same.

Instead of adding Zellij support to `fzfw`, a new script is written. `fzfw` will be kept as a reference, but similar features will be added to `fzjt` and additional functionalities will be added as new scripts under `/zellij` since I stopped using `tmux`.